### PR TITLE
Add setup script for Codex

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Setup script to install dependencies for Codex
+set -e
+npm install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidelines for Codex
+
+- Run `npm test` before committing
+- Follow ESLint rules from `eslint.config.js`
+- Document new components in `README.md`


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install dependencies automatically

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c3c5a7310832cb312656122461e62