### PR TITLE
Sync RPC types

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ This project uses Supabase with RPC-first design for secure, typed, and scalable
 - Add new columns? Just update RPCs — frontend stays untouched
 - Need WKT parsing? Always handle in frontend using `parseWktToGeoJson`
 - Use composite keys carefully (e.g. `user_contracts` needs `user_id + contract_id` for delete)
+- Outdated profile contract RPCs were removed from `rpc.client.ts`
 
 ---
 This structure gives you a true API-less, secure backend with full control and complete type safety.

--- a/src/lib/rpc.client.ts
+++ b/src/lib/rpc.client.ts
@@ -107,13 +107,6 @@ class RpcClient {
     return this.callRpc<void>('update_contract', args);
   }
 
-  async removeProfileFromContract(args: { _contract_id: string; _profile_id: string }): Promise<void> {
-    return this.callRpc<void>('remove_profile_from_contract', args);
-  }
-
-  async updateProfileContractRole(args: { _contract_id: string; _profile_id: string; _role: string }): Promise<void> {
-    return this.callRpc<void>('update_profile_contract_role', args);
-  }
 
   async deleteContracts(args: RPC.DeleteContractsRpcArgs): Promise<void> {
     return this.callRpc<void>('delete_contract', args);

--- a/src/lib/rpc.types.ts
+++ b/src/lib/rpc.types.ts
@@ -454,6 +454,21 @@ export type InsertChangeOrderRpcArgs = {
 };
 export type InsertChangeOrderRpc = (args: InsertChangeOrderRpcArgs) => Promise<string>;
 
+export type InsertContractRpcArgs = {
+  title: string;
+  location: string;
+  start_date: string;
+  end_date: string;
+  status?: Database["public"]["Enums"]["contract_status"];
+  budget?: number;
+  description?: string;
+  coordinates?: Record<string, unknown>;
+  created_by?: string;
+};
+export type InsertContractRpc = (
+  args: InsertContractRpcArgs
+) => Promise<string>;
+
 export type InsertContractOrganizationRpcArgs = {
   contract_id: string;
   organization_id: string;
@@ -709,6 +724,83 @@ export type UpdateContractRpcArgs = {
   _coordinates?: unknown;
 };
 export type UpdateContractRpc = (args: UpdateContractRpcArgs) => Promise<void>;
+
+export type UpdateAsphaltTypeRpcArgs = {
+  _id: string;
+  _name?: string;
+  _compaction_min?: number;
+  _jmf_temp_max?: number;
+  _jmf_temp_min?: number;
+  _lift_depth_inches?: number;
+  _notes?: string;
+  _target_spread_rate_lbs_per_sy?: number;
+};
+export type UpdateAsphaltTypeRpc = (
+  args: UpdateAsphaltTypeRpcArgs
+) => Promise<void>;
+
+export type UpdateChangeOrderRpcArgs = {
+  _id: string;
+  _title?: string;
+  _description?: string;
+  _attachments?: string[];
+  _new_quantity?: number;
+  _new_unit_price?: number;
+  _status?: Database["public"]["Enums"]["change_order_status"];
+  _approved_by?: string;
+  _approved_date?: string;
+  _updated_by?: string;
+};
+export type UpdateChangeOrderRpc = (
+  args: UpdateChangeOrderRpcArgs
+) => Promise<void>;
+
+export type UpdateContractOrganizationRpcArgs = {
+  _id: string;
+  _role?: Database["public"]["Enums"]["organization_role"];
+  _notes?: string;
+  _updated_at?: string;
+};
+export type UpdateContractOrganizationRpc = (
+  args: UpdateContractOrganizationRpcArgs
+) => Promise<void>;
+
+export type UpdateDumpTruckRpcArgs = {
+  _id: string;
+  _payload_capacity_tons?: number;
+  _truck_identifier?: string;
+  _axle_count?: number;
+  _bed_height?: number;
+  _bed_length?: number;
+  _bed_volume?: number;
+  _bed_width?: number;
+  _contract_id?: string;
+  _equipment_id?: string;
+  _hoist_bottom?: number;
+  _hoist_top?: number;
+  _hoist_width?: number;
+  _notes?: string;
+  _weight_capacity_tons?: number;
+};
+export type UpdateDumpTruckRpc = (
+  args: UpdateDumpTruckRpcArgs
+) => Promise<void>;
+
+export type UpdateLineItemEntryRpcArgs = {
+  _id: string;
+  _computed_output?: number;
+  _contract_id?: string;
+  _line_item_id?: string;
+  _map_id?: string;
+  _input_variables?: Record<string, unknown>;
+  _notes?: string;
+  _output_unit?: Database["public"]["Enums"]["unit_measure_type"];
+  _entered_by?: string;
+  _wbs_id?: string;
+};
+export type UpdateLineItemEntryRpc = (
+  args: UpdateLineItemEntryRpcArgs
+) => Promise<void>;
 
 export type UpdateLaborRecordRpcArgs = {
   id: string;


### PR DESCRIPTION
## Summary
- generate new RPC typings for InsertContract and update RPC helpers
- remove old profile-contract helpers from `rpc.client`
- mention removal in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c6691d728832cbb71ffa8db0f05ae