### PR TITLE
Replace vendor names with core feature tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,12 @@ This project uses Supabase with RPC-first design for secure, typed, and scalable
 
 ---
 This structure gives you a true API-less, secure backend with full control and complete type safety.
+## 🏗 Core Feature Types
+Typed interfaces for project management, estimating, cost codes, and scheduling live in `src/lib/features`.
+
+## 🚀 Built-in Feature Pages
+Macadamy includes pages for these core construction features:
+- `/projects` &mdash; manage projects
+- `/estimates` &mdash; track estimates and contracts
+- `/cost-codes` &mdash; maintain cost codes
+- `/schedule-tasks` &mdash; review schedules

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,11 @@ const Inspections        = lazy(() => import('@/pages/Contract/Inspections'));
 const Issues             = lazy(() => import('@/pages/Contract/Issues'));
 const DailyReports       = lazy(() => import('@/pages/Contract/DailyReports'));
 
+const Projects           = lazy(() => import('@/pages/Features/Projects'));
+const Estimates          = lazy(() => import('@/pages/Features/Estimates'));
+const CostCodes          = lazy(() => import('@/pages/Features/CostCodes'));
+const ScheduleTasks      = lazy(() => import('@/pages/Features/ScheduleTasks'));
+
 const NotFoundPage       = lazy(() => import('@/pages/StandardPages/NotFoundPage'));
 
 /* ── component ─────────────────────────────────────────────────── */
@@ -212,6 +217,40 @@ export default function App(): JSX.Element {
             element={
               <ProtectedRoute>
                 <DailyReports />
+              </ProtectedRoute>
+            }
+          />
+
+          {/* Core features */}
+          <Route
+            path="/projects"
+            element={
+              <ProtectedRoute>
+                <Projects />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/estimates"
+            element={
+              <ProtectedRoute>
+                <Estimates />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/cost-codes"
+            element={
+              <ProtectedRoute>
+                <CostCodes />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/schedule-tasks"
+            element={
+              <ProtectedRoute>
+                <ScheduleTasks />
               </ProtectedRoute>
             }
           />

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1678,6 +1678,146 @@ export type Database = {
           },
         ]
       }
+      projects: {
+        Row: {
+          id: string
+          external_id: string
+          contract_id: string
+          name: string
+          start_date: string | null
+          end_date: string | null
+        }
+        Insert: {
+          id?: string
+          external_id: string
+          contract_id: string
+          name: string
+          start_date?: string | null
+          end_date?: string | null
+        }
+        Update: {
+          id?: string
+          external_id?: string
+          contract_id?: string
+          name?: string
+          start_date?: string | null
+          end_date?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "projects_contract_id_fkey"
+            columns: ["contract_id"]
+            isOneToOne: false
+            referencedRelation: "contracts"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      estimates: {
+        Row: {
+          id: string
+          external_id: string
+          contract_id: string
+          title: string
+          amount: number
+          status: string | null
+        }
+        Insert: {
+          id?: string
+          external_id: string
+          contract_id: string
+          title: string
+          amount: number
+          status?: string | null
+        }
+        Update: {
+          id?: string
+          external_id?: string
+          contract_id?: string
+          title?: string
+          amount?: number
+          status?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "estimates_contract_id_fkey"
+            columns: ["contract_id"]
+            isOneToOne: false
+            referencedRelation: "contracts"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      cost_codes: {
+        Row: {
+          id: string
+          external_id: string
+          contract_id: string
+          code: string
+          description: string | null
+        }
+        Insert: {
+          id?: string
+          external_id: string
+          contract_id: string
+          code: string
+          description?: string | null
+        }
+        Update: {
+          id?: string
+          external_id?: string
+          contract_id?: string
+          code?: string
+          description?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cost_codes_contract_id_fkey"
+            columns: ["contract_id"]
+            isOneToOne: false
+            referencedRelation: "contracts"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      schedule_tasks: {
+        Row: {
+          id: string
+          external_id: string
+          contract_id: string
+          name: string
+          start_date: string | null
+          end_date: string | null
+          percent_complete: number | null
+        }
+        Insert: {
+          id?: string
+          external_id: string
+          contract_id: string
+          name: string
+          start_date?: string | null
+          end_date?: string | null
+          percent_complete?: number | null
+        }
+        Update: {
+          id?: string
+          external_id?: string
+          contract_id?: string
+          name?: string
+          start_date?: string | null
+          end_date?: string | null
+          percent_complete?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "schedule_tasks_contract_id_fkey"
+            columns: ["contract_id"]
+            isOneToOne: false
+            referencedRelation: "contracts"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
     }
     Views: {
       geography_columns: {

--- a/src/lib/features/cost-code.types.ts
+++ b/src/lib/features/cost-code.types.ts
@@ -1,0 +1,7 @@
+export interface CostCode {
+  id: string;
+  externalId: string;
+  contractId: string;
+  code: string;
+  description: string | null;
+}

--- a/src/lib/features/estimate.types.ts
+++ b/src/lib/features/estimate.types.ts
@@ -1,0 +1,8 @@
+export interface Estimate {
+  id: string;
+  externalId: string;
+  contractId: string;
+  title: string;
+  amount: number;
+  status: string | null;
+}

--- a/src/lib/features/index.ts
+++ b/src/lib/features/index.ts
@@ -1,0 +1,4 @@
+export * from './project.types';
+export * from './estimate.types';
+export * from './cost-code.types';
+export * from './schedule-task.types';

--- a/src/lib/features/project.types.ts
+++ b/src/lib/features/project.types.ts
@@ -1,0 +1,8 @@
+export interface Project {
+  id: string;
+  externalId: string;
+  contractId: string;
+  name: string;
+  startDate: string | null;
+  endDate: string | null;
+}

--- a/src/lib/features/schedule-task.types.ts
+++ b/src/lib/features/schedule-task.types.ts
@@ -1,0 +1,9 @@
+export interface ScheduleTask {
+  id: string;
+  externalId: string;
+  contractId: string;
+  name: string;
+  startDate: string | null;
+  endDate: string | null;
+  percentComplete: number | null;
+}

--- a/src/lib/functions.sql
+++ b/src/lib/functions.sql
@@ -6095,3 +6095,77 @@ ALTER TABLE public.wbs ENABLE ROW LEVEL SECURITY;
 -- PostgreSQL database dump complete
 --
 
+-- Simple CRUD functions for new feature tables
+
+CREATE FUNCTION public.insert_project(
+  _external_id text,
+  _contract_id uuid,
+  _name text,
+  _start_date date,
+  _end_date date
+) RETURNS uuid LANGUAGE sql AS $$
+  INSERT INTO projects (external_id, contract_id, name, start_date, end_date)
+  VALUES (_external_id, _contract_id, _name, _start_date, _end_date)
+  RETURNING id;
+$$;
+
+CREATE FUNCTION public.update_project(
+  _id uuid,
+  _name text,
+  _start_date date,
+  _end_date date
+) RETURNS void LANGUAGE sql AS $$
+  UPDATE projects
+  SET name = COALESCE(_name, name),
+      start_date = COALESCE(_start_date, start_date),
+      end_date = COALESCE(_end_date, end_date)
+  WHERE id = _id;
+$$;
+
+CREATE FUNCTION public.delete_project(_id uuid) RETURNS void LANGUAGE sql AS $$
+  DELETE FROM projects WHERE id = _id;
+$$;
+
+CREATE FUNCTION public.insert_estimate(
+  _external_id text,
+  _contract_id uuid,
+  _title text,
+  _amount numeric,
+  _status text
+) RETURNS uuid LANGUAGE sql AS $$
+  INSERT INTO estimates (external_id, contract_id, title, amount, status)
+  VALUES (_external_id, _contract_id, _title, _amount, _status)
+  RETURNING id;
+$$;
+
+CREATE FUNCTION public.delete_estimate(_id uuid) RETURNS void LANGUAGE sql AS $$
+  DELETE FROM estimates WHERE id = _id;
+$$;
+
+CREATE FUNCTION public.insert_cost_code(
+  _external_id text,
+  _contract_id uuid,
+  _code text,
+  _description text
+) RETURNS uuid LANGUAGE sql AS $$
+  INSERT INTO cost_codes (external_id, contract_id, code, description)
+  VALUES (_external_id, _contract_id, _code, _description)
+  RETURNING id;
+$$;
+
+CREATE FUNCTION public.insert_schedule_task(
+  _external_id text,
+  _contract_id uuid,
+  _name text,
+  _start_date date,
+  _end_date date,
+  _percent_complete numeric
+) RETURNS uuid LANGUAGE sql AS $$
+  INSERT INTO schedule_tasks (
+    external_id, contract_id, name, start_date, end_date, percent_complete
+  ) VALUES (
+    _external_id, _contract_id, _name, _start_date, _end_date, _percent_complete
+  )
+  RETURNING id;
+$$;
+

--- a/src/lib/rpc.client.ts
+++ b/src/lib/rpc.client.ts
@@ -130,6 +130,35 @@ class RpcClient {
   async deleteLaborRecord(args: RPC.DeleteLaborRecordRpcArgs): Promise<void> {
     return this.callRpc<void>('delete_labor_record', args);
   }
+
+  // ----- Core Feature RPCs -----
+  async insertProject(args: RPC.InsertProjectRpcArgs): Promise<string> {
+    return this.callRpc<string>('insert_project', args);
+  }
+
+  async updateProject(args: RPC.UpdateProjectRpcArgs): Promise<void> {
+    await this.callRpc<void>('update_project', args);
+  }
+
+  async deleteProject(args: RPC.DeleteProjectRpcArgs): Promise<void> {
+    await this.callRpc<void>('delete_project', args);
+  }
+
+  async insertEstimate(args: RPC.InsertEstimateRpcArgs): Promise<string> {
+    return this.callRpc<string>('insert_estimate', args);
+  }
+
+  async deleteEstimate(args: RPC.DeleteEstimateRpcArgs): Promise<void> {
+    await this.callRpc<void>('delete_estimate', args);
+  }
+
+  async insertCostCode(args: RPC.InsertCostCodeRpcArgs): Promise<string> {
+    return this.callRpc<string>('insert_cost_code', args);
+  }
+
+  async insertScheduleTask(args: RPC.InsertScheduleTaskRpcArgs): Promise<string> {
+    return this.callRpc<string>('insert_schedule_task', args);
+  }
 }
 
 export const rpcClient = new RpcClient();

--- a/src/lib/rpc.types.ts
+++ b/src/lib/rpc.types.ts
@@ -826,3 +826,56 @@ export type UpdateProfileRpcArgs = {
   _organization_id?: string;
 };
 export type UpdateProfileRpc = (args: UpdateProfileRpcArgs) => Promise<void>;
+
+// ----- Core Feature RPC Types -----
+export type InsertProjectRpcArgs = {
+  _external_id: string;
+  _contract_id: string;
+  _name: string;
+  _start_date: string;
+  _end_date: string;
+};
+export type InsertProjectRpc = (args: InsertProjectRpcArgs) => Promise<string>;
+
+export type UpdateProjectRpcArgs = {
+  _id: string;
+  _name?: string;
+  _start_date?: string;
+  _end_date?: string;
+};
+export type UpdateProjectRpc = (args: UpdateProjectRpcArgs) => Promise<void>;
+
+export type DeleteProjectRpcArgs = { _id: string };
+export type DeleteProjectRpc = (args: DeleteProjectRpcArgs) => Promise<void>;
+
+export type InsertEstimateRpcArgs = {
+  _external_id: string;
+  _contract_id: string;
+  _title: string;
+  _amount: number;
+  _status: string;
+};
+export type InsertEstimateRpc = (args: InsertEstimateRpcArgs) => Promise<string>;
+
+export type DeleteEstimateRpcArgs = { _id: string };
+export type DeleteEstimateRpc = (args: DeleteEstimateRpcArgs) => Promise<void>;
+
+export type InsertCostCodeRpcArgs = {
+  _external_id: string;
+  _contract_id: string;
+  _code: string;
+  _description: string;
+};
+export type InsertCostCodeRpc = (args: InsertCostCodeRpcArgs) => Promise<string>;
+
+export type InsertScheduleTaskRpcArgs = {
+  _external_id: string;
+  _contract_id: string;
+  _name: string;
+  _start_date: string;
+  _end_date: string;
+  _percent_complete: number;
+};
+export type InsertScheduleTaskRpc = (
+  args: InsertScheduleTaskRpcArgs
+) => Promise<string>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -422,3 +422,9 @@ export interface Calculation {
   created_at?: string;
   created_by?: string;
 }
+
+// Core Feature Types
+export type { Project } from './features/project.types';
+export type { Estimate } from './features/estimate.types';
+export type { CostCode } from './features/cost-code.types';
+export type { ScheduleTask } from './features/schedule-task.types';

--- a/src/pages/Features/CostCodes.tsx
+++ b/src/pages/Features/CostCodes.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { Page } from '@/pages/StandardPages/StandardPageComponents/Page';
+import { supabase } from '@/lib/supabase';
+import type { Database } from '@/lib/database.types';
+
+type CostCodeRow = Database['public']['Tables']['cost_codes']['Row'];
+
+export default function CostCodes() {
+  const [codes, setCodes] = useState<CostCodeRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data, error } = await supabase
+        .from('cost_codes')
+        .select('*')
+        .returns<CostCodeRow[]>();
+      if (error) {
+        console.error('Error fetching cost codes', error);
+      } else if (data) {
+        setCodes(data);
+      }
+      setLoading(false);
+    };
+    void fetchData();
+  }, []);
+
+  if (loading) return <Page>Loading…</Page>;
+
+  return (
+    <Page>
+      <h1 className="text-2xl font-bold mb-4">Cost Codes</h1>
+      <ul className="space-y-2">
+        {codes.map(c => (
+          <li key={c.id} className="border p-2 rounded">
+            <span className="font-medium">{c.code}</span>
+            <span className="ml-2 text-sm text-gray-500">{c.description}</span>
+          </li>
+        ))}
+      </ul>
+    </Page>
+  );
+}

--- a/src/pages/Features/Estimates.tsx
+++ b/src/pages/Features/Estimates.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { Page } from '@/pages/StandardPages/StandardPageComponents/Page';
+import { supabase } from '@/lib/supabase';
+import type { Database } from '@/lib/database.types';
+
+type EstimateRow = Database['public']['Tables']['estimates']['Row'];
+
+export default function Estimates() {
+  const [estimates, setEstimates] = useState<EstimateRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data, error } = await supabase
+        .from('estimates')
+        .select('*')
+        .returns<EstimateRow[]>();
+      if (error) {
+        console.error('Error fetching estimates', error);
+      } else if (data) {
+        setEstimates(data);
+      }
+      setLoading(false);
+    };
+    void fetchData();
+  }, []);
+
+  if (loading) return <Page>Loading…</Page>;
+
+  return (
+    <Page>
+      <h1 className="text-2xl font-bold mb-4">Estimates</h1>
+      <ul className="space-y-2">
+        {estimates.map(e => (
+          <li key={e.id} className="border p-2 rounded">
+            <span className="font-medium">{e.title}</span>
+            <span className="ml-2 text-sm text-gray-500">
+              ${'{'}e.amount{'}'} ({e.status ?? 'N/A'})
+            </span>
+          </li>
+        ))}
+      </ul>
+    </Page>
+  );
+}

--- a/src/pages/Features/Projects.tsx
+++ b/src/pages/Features/Projects.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { Page } from '@/pages/StandardPages/StandardPageComponents/Page';
+import { supabase } from '@/lib/supabase';
+import type { Database } from '@/lib/database.types';
+
+type ProjectRow = Database['public']['Tables']['projects']['Row'];
+
+export default function Projects() {
+  const [projects, setProjects] = useState<ProjectRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data, error } = await supabase
+        .from('projects')
+        .select('*')
+        .returns<ProjectRow[]>();
+      if (error) {
+        console.error('Error fetching projects', error);
+      } else if (data) {
+        setProjects(data);
+      }
+      setLoading(false);
+    };
+    void fetchData();
+  }, []);
+
+  if (loading) return <Page>Loading…</Page>;
+
+  return (
+    <Page>
+      <h1 className="text-2xl font-bold mb-4">Projects</h1>
+      <ul className="space-y-2">
+        {projects.map(p => (
+          <li key={p.id} className="border p-2 rounded">
+            <span className="font-medium">{p.name}</span>
+            <span className="ml-2 text-sm text-gray-500">
+              {p.start_date ?? 'N/A'} – {p.end_date ?? 'N/A'}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </Page>
+  );
+}

--- a/src/pages/Features/ScheduleTasks.tsx
+++ b/src/pages/Features/ScheduleTasks.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { Page } from '@/pages/StandardPages/StandardPageComponents/Page';
+import { supabase } from '@/lib/supabase';
+import type { Database } from '@/lib/database.types';
+
+type TaskRow = Database['public']['Tables']['schedule_tasks']['Row'];
+
+export default function ScheduleTasks() {
+  const [tasks, setTasks] = useState<TaskRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data, error } = await supabase
+        .from('schedule_tasks')
+        .select('*')
+        .returns<TaskRow[]>();
+      if (error) {
+        console.error('Error fetching tasks', error);
+      } else if (data) {
+        setTasks(data);
+      }
+      setLoading(false);
+    };
+    void fetchData();
+  }, []);
+
+  if (loading) return <Page>Loading…</Page>;
+
+  return (
+    <Page>
+      <h1 className="text-2xl font-bold mb-4">Schedule Tasks</h1>
+      <ul className="space-y-2">
+        {tasks.map(t => (
+          <li key={t.id} className="border p-2 rounded">
+            <span className="font-medium">{t.name}</span>
+            <span className="ml-2 text-sm text-gray-500">
+              {t.start_date ?? 'N/A'} – {t.end_date ?? 'N/A'}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary
- rename integration types to internal feature types and move to `src/lib/features`
- switch routes and pages to `/projects`, `/estimates`, `/cost-codes`, `/schedule-tasks`
- add CRUD RPCs for new feature tables
- update Supabase types and README documentation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686c9773cd20832cb8ec678d71693145