### PR TITLE
Rename contract components to project

### DIFF
--- a/src/lib/ui.types.ts
+++ b/src/lib/ui.types.ts
@@ -105,9 +105,9 @@ export interface DashboardComponentBase {
 }
 
 /**
- * Common contract header props
+ * Common project header props
  */
-export interface ContractHeaderProps extends DashboardComponentBase {
+export interface ProjectHeaderProps extends DashboardComponentBase {
   /**
    * Contract data
    */
@@ -127,9 +127,9 @@ export interface ContractHeaderProps extends DashboardComponentBase {
 }
 
 /**
- * Contract info form props
+ * Project info form props
  */
-export interface ContractInfoFormProps extends DashboardComponentBase {
+export interface ProjectInfoFormProps extends DashboardComponentBase {
   /**
    * Contract data
    */
@@ -149,9 +149,9 @@ export interface ContractInfoFormProps extends DashboardComponentBase {
 }
 
 /**
- * Contract totals panel props
+ * Project totals panel props
  */
-export interface ContractTotalsPanelProps extends DashboardComponentBase {
+export interface ProjectTotalsPanelProps extends DashboardComponentBase {
   /**
    * Total budget for the contract
    */

--- a/src/pages/Contract/ContractCreation.tsx
+++ b/src/pages/Contract/ContractCreation.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Page } from '@/pages/StandardPages/StandardPageComponents/Page';
 import { Card } from '@/pages/StandardPages/StandardPageComponents/card';
 import { Button } from '@/pages/StandardPages/StandardPageComponents/button';
-import { ContractInfoForm } from './ContractDasboardComponents/ContractInfoForm';
+import { ProjectInfoForm } from './ContractDasboardComponents/ProjectInfoForm';
 import { MapModal } from './SharedComponents/MapModal';
 import { MapPreview } from './SharedComponents/GoogleMaps/MapPreview';
 import { parseWktToGeoJson, geometryToWKT } from '@/lib/utils/geometryUtils';
@@ -102,7 +102,7 @@ export const ContractCreation = () => {
             <div className="p-6">
               <h1 className="text-2xl font-bold mb-6">Create New Contract</h1>
 
-              <ContractInfoForm contractData={contractData as ContractWithWktRow} />
+              <ProjectInfoForm contractData={contractData as ContractWithWktRow} />
 
               <div className="mt-6 border-t border-gray-700 pt-6">
                 <h2 className="text-lg font-semibold mb-4">Location</h2>

--- a/src/pages/Contract/ContractDasboardComponents/ProjectHeader.tsx
+++ b/src/pages/Contract/ContractDasboardComponents/ProjectHeader.tsx
@@ -7,7 +7,7 @@ import type { ContractWithWktRow } from '@/lib/rpc.types';
 import { ErrorBoundary } from 'react-error-boundary';
 import { CalendarRange, MapPin } from 'lucide-react';
 
-interface ContractHeaderProps {
+interface ProjectHeaderProps {
   /**
    * Contract data
    */
@@ -31,23 +31,23 @@ const ErrorFallback = ({ error, resetErrorBoundary }: { error: Error; resetError
       <ErrorState
         error={error}
         onRetry={resetErrorBoundary}
-        title="Error Loading Contract Header"
+        title="Error Loading Project Header"
       />
     </div>
   </Card>
 );
 
 /**
- * ContractHeader Component
+ * ProjectHeader Component
  * 
  * Displays the contract header information including title, status, location,
  * description, map button, and contract period.
  */
-export function ContractHeader({
+export function ProjectHeader({
   contract,
   isLoading = false,
   error = null
-}: ContractHeaderProps) {
+}: ProjectHeaderProps) {
   const [contractData, setContractData] = useState<ContractWithWktRow>(contract);
 
   // Update local state when contract prop changes
@@ -82,7 +82,7 @@ export function ContractHeader({
       <Card className="mb-6">
         <ErrorState
           error={error instanceof Error ? error : String(error)}
-          title="Error Loading Contract Header"
+          title="Error Loading Project Header"
         />
       </Card>
     );

--- a/src/pages/Contract/ContractDasboardComponents/ProjectInfoForm.tsx
+++ b/src/pages/Contract/ContractDasboardComponents/ProjectInfoForm.tsx
@@ -1,4 +1,4 @@
-// filepath: src\pages\Contract\ContractDasboardComponents\ContractInfoForm.tsx
+// filepath: src\pages\Contract\ContractDasboardComponents\ProjectInfoForm.tsx
 import { useState, useEffect } from 'react';
 import { GeometryButton } from '@/pages/Contract/SharedComponents/GoogleMaps/GeometryButton';
 import type { ContractWithWktRow } from '@/lib/rpc.types';
@@ -11,18 +11,18 @@ import { motion, AnimatePresence } from 'framer-motion';
 import toast from 'react-hot-toast';
 import { supabase } from '@/lib/supabase';
 
-interface ContractInfoFormProps {
+interface ProjectInfoFormProps {
   contractData: ContractWithWktRow;
 }
 
 /**
- * ContractInfoForm Component
+ * ProjectInfoForm Component
  * 
  * Displays contract information with compact/detailed view toggle.
  * Enhanced with map integration, document viewer, and real-time updates.
  * This is a view-only component.
  */
-export function ContractInfoForm({ contractData }: ContractInfoFormProps) {
+export function ProjectInfoForm({ contractData }: ProjectInfoFormProps) {
   const [isDetailedView, setIsDetailedView] = useState(false);
   const [attachments, setAttachments] = useState<Array<{ name: string, url: string, type: string, size: number }>>([]);
   const [isLoadingAttachments, setIsLoadingAttachments] = useState(false);

--- a/src/pages/Contract/ContractDasboardComponents/ProjectTools.tsx
+++ b/src/pages/Contract/ContractDasboardComponents/ProjectTools.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-interface ContractToolsProps {
+interface ProjectToolsProps {
   contractId: string;
   issuesCount?: number; // Added to receive as prop
   changeOrdersCount?: number; // Added to receive as prop
@@ -19,13 +19,13 @@ export interface ToolButton {
 }
 
 /**
- * ContractToolbar Component - Now View-Only
+ * ProjectToolbar Component - Now View-Only
  * 
  * Provides quick access to various contract management features.
  * All tools are navigational and do not perform write operations directly.
  * Badge counts are for display purposes only.
  */
-export const ContractTools: React.FC<ContractToolsProps> = ({
+export const ProjectTools: React.FC<ProjectToolsProps> = ({
   contractId,
   issuesCount = 0, // Default to 0 if not provided
   changeOrdersCount = 0, // Default to 0

--- a/src/pages/Contract/ContractDasboardComponents/ProjectTotalsPanel.tsx
+++ b/src/pages/Contract/ContractDasboardComponents/ProjectTotalsPanel.tsx
@@ -1,18 +1,18 @@
-// filepath: src\pages\Contract\ContractDasboardComponents\ContractTotalsPanel.tsx
+// filepath: src\pages\Contract\ContractDasboardComponents\ProjectTotalsPanel.tsx
 import React, { useState } from 'react';
 import { Card } from '@/pages/StandardPages/StandardPageComponents/card';
 import { BudgetTracker } from '../SharedComponents/BudgetProgressBar';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
-interface ContractTotalsPanelProps {
+interface ProjectTotalsPanelProps {
   totalBudget: number;
   lineItemsTotal: number;
   budgetRemaining: number;
   percentUsed: number;
 }
 
-export const ContractTotalsPanel: React.FC<ContractTotalsPanelProps> = ({
+export const ProjectTotalsPanel: React.FC<ProjectTotalsPanelProps> = ({
   totalBudget,
   lineItemsTotal,
   budgetRemaining,

--- a/src/pages/Contract/ContractDashboard.tsx
+++ b/src/pages/Contract/ContractDashboard.tsx
@@ -2,10 +2,10 @@
  * Contract Dashboard
  * 
  * Enhanced with comprehensive improvements across all components:
- * - ContractHeader: Converted to functional component with hooks, improved error handling
- * - ContractTools: Added tooltips, permission checks, badges, and real-time updates
- * - ContractTotalsPanel: Added trend visualization, forecasting, drill-down, and export
- * - ContractInfoForm: Added compact/detailed view toggle, edit capabilities
+ * - ProjectHeader: Converted to functional component with hooks, improved error handling
+ * - ProjectTools: Added tooltips, permission checks, badges, and real-time updates
+ * - ProjectTotalsPanel: Added trend visualization, forecasting, drill-down, and export
+ * - ProjectInfoForm: Added compact/detailed view toggle, edit capabilities
  * - WbsSection: Added expand/collapse, sorting, filtering, and improved UI
  * - LineItemsTable: Added pagination, sorting, filtering, and improved accessibility
  */
@@ -20,12 +20,12 @@ import { EmptyState } from '@/components/ui/empty-state';
 import type { ContractWithWktRow, WbsWithWktRow, LineItemsWithWktRow } from '@/lib/rpc.types';
 import { UnitMeasureType } from '@/lib/enums';
 
-import { ContractHeader } from './ContractDasboardComponents/ContractHeader';
-import { ContractInfoForm } from './ContractDasboardComponents/ContractInfoForm';
-import { ContractTotalsPanel } from './ContractDasboardComponents/ContractTotalsPanel';
+import { ProjectHeader } from './ContractDasboardComponents/ProjectHeader';
+import { ProjectInfoForm } from './ContractDasboardComponents/ProjectInfoForm';
+import { ProjectTotalsPanel } from './ContractDasboardComponents/ProjectTotalsPanel';
 import { WbsSection } from './ContractDasboardComponents/WbsSection';
 import { LineItemsTable } from './ContractDasboardComponents/LineItemsTable';
-import { ContractTools } from './ContractDasboardComponents/ContractTools';
+import { ProjectTools } from './ContractDasboardComponents/ProjectTools';
 
 export default function ContractDashboard() {
   const { contractId } = useParams<{ contractId: string }>();
@@ -232,11 +232,11 @@ export default function ContractDashboard() {
     <Page>
       <PageContainer>
         <div className="container mx-auto px-4 py-6">
-          <ContractHeader
+          <ProjectHeader
             contract={contract}
           />
 
-          <ContractTools
+          <ProjectTools
             contractId={contract.id}
             issuesCount={issuesCount}
             changeOrdersCount={changeOrdersCount}
@@ -245,12 +245,12 @@ export default function ContractDashboard() {
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
             <div className="lg:col-span-2">
-              <ContractInfoForm
+              <ProjectInfoForm
                 contractData={contract}
               />
             </div>
             <div className="lg:col-span-1">
-              <ContractTotalsPanel
+              <ProjectTotalsPanel
                 totalBudget={typeof contract.budget === 'number' ? contract.budget : 0}
                 lineItemsTotal={lineItems.reduce((acc, item) => acc + (typeof item.quantity === 'number' && typeof item.unit_price === 'number' ? item.quantity * item.unit_price : 0), 0)}
                 budgetRemaining={(typeof contract.budget === 'number' ? contract.budget : 0) - lineItems.reduce((acc, item) => acc + (typeof item.quantity === 'number' && typeof item.unit_price === 'number' ? item.quantity * item.unit_price : 0), 0)}


### PR DESCRIPTION
## Summary
- rename dashboard component files from `Contract*` to `Project*`
- update imports and usages to new names
- rename related prop interfaces in `ui.types.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ea54cca8c832c8cd4e35a621c9114