### PR TITLE
Add design review and equipment maintenance features

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Macadamy includes pages for these core construction features:
 - `/document-management` &mdash; drawings, RFIs and submittals
 - `/financial-management` &mdash; budgets and billing
 - `/field-operations` &mdash; timecards and equipment logs
+- `/equipment-management` &mdash; inventory, maintenance, and service history
+- `/design-reviews` &mdash; track model coordination reviews
+- `/equipment-maintenance` &mdash; schedule service and log repairs
 - `/accounting-payroll` &mdash; AP/AR and payroll tracking
 - `/resource-planning` &mdash; schedules and resource allocation
 - `/reporting` &mdash; dashboards and analytics
@@ -111,7 +114,7 @@ Macadamy includes pages for these core construction features:
 - `/subcontractors` &mdash; vendor onboarding and agreements
 
 ## 🚧 Comprehensive Feature Vision
-Our long-term roadmap aims to match the capabilities of leading construction and project management platforms. Major areas include:
+Our long-term roadmap aims to match the capabilities of leading construction and project management solutions while implementing everything natively without external API dependencies. Major areas include:
 
 ### Preconstruction & Bidding
 - Detailed estimating with resource-based pricing
@@ -120,6 +123,7 @@ Our long-term roadmap aims to match the capabilities of leading construction and
 
 ### Project & Document Management
 - Drawing version control and centralized file storage
+- Model coordination and design review
 - RFI, submittal, and meeting minutes workflows
 - Daily logs, change orders, and punch lists
 
@@ -132,6 +136,7 @@ Our long-term roadmap aims to match the capabilities of leading construction and
 ### Field Operations
 - Timecards and production quantity tracking
 - Equipment assignments and usage logs
+- Equipment maintenance scheduling and service history
 - Safety inspections and incident reporting
 
 ### Accounting & Payroll
@@ -150,6 +155,12 @@ Our long-term roadmap aims to match the capabilities of leading construction and
 - Custom dashboards and analytics
 - Mobile access to tasks and documents
 - Centralized contact directory and communications
+
+### Future Enhancements (TODO)
+- BIM coordination and model federation
+- Drone & sensor data integration
+- Regulatory compliance tracking
+- 3rd-party app integrations
 
 ## 🐛 Troubleshooting Authentication
 If you see an error like `error running hook URI: pg-functions://postgres/public/custom-access-token_hook` during sign-in, the database function for custom access tokens may be missing.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,9 @@ const ReportingCollaboration = lazy(() => import('@/pages/Features/ReportingColl
 const OrganizationDashboard = lazy(() => import('@/pages/Organization/OrganizationDashboard'));
 const QualitySafety = lazy(() => import("@/pages/Features/QualitySafety"));
 const SubcontractorManagement = lazy(() => import("@/pages/Features/SubcontractorManagement"));
+const EquipmentManagement = lazy(() => import('@/pages/Features/EquipmentManagement'));
+const DesignReviews = lazy(() => import('@/pages/Features/DesignReviews'));
+const EquipmentMaintenance = lazy(() => import('@/pages/Features/EquipmentMaintenance'));
 
 const NotFoundPage       = lazy(() => import('@/pages/StandardPages/NotFoundPage'));
 
@@ -301,6 +304,30 @@ export default function App(): JSX.Element {
             element={
               <ProtectedRoute>
                 <FieldOperations />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/equipment-management"
+            element={
+              <ProtectedRoute>
+                <EquipmentManagement />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/design-reviews"
+            element={
+              <ProtectedRoute>
+                <DesignReviews />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/equipment-maintenance"
+            element={
+              <ProtectedRoute>
+                <EquipmentMaintenance />
               </ProtectedRoute>
             }
           />

--- a/src/pages/Features/DesignReviews.tsx
+++ b/src/pages/Features/DesignReviews.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { Page } from '@/components/Layout';
+import { supabase } from '@/lib/supabase';
+import type { Database } from '@/lib/database.types';
+
+// Row type for design_reviews table
+interface DesignReview extends Pick<Database['public']['Tables']['projects']['Row'], 'id'> {
+  title: string;
+  status: string | null;
+  notes: string | null;
+  review_date: string | null;
+  created_at: string | null;
+}
+
+export default function DesignReviews() {
+  const [reviews, setReviews] = useState<DesignReview[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchReviews = async () => {
+      const { data, error } = await supabase.from('design_reviews').select('*');
+      if (!error && Array.isArray(data)) {
+        setReviews(data as unknown as DesignReview[]);
+      }
+      setLoading(false);
+    };
+    void fetchReviews();
+  }, []);
+
+  if (loading) return <Page>Loading…</Page>;
+
+  return (
+    <Page>
+      <h1 className="text-2xl font-bold mb-4">Design Reviews</h1>
+      <ul className="space-y-2">
+        {reviews.map(r => (
+          <li key={r.id} className="border p-2 rounded">
+            <span className="font-medium">{r.title}</span>
+            {r.review_date && (
+              <span className="ml-2 text-sm text-gray-500">{r.review_date}</span>
+            )}
+            {r.status && (
+              <span className="ml-2 text-sm text-gray-500">[{r.status}]</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </Page>
+  );
+}

--- a/src/pages/Features/DocumentManagement.tsx
+++ b/src/pages/Features/DocumentManagement.tsx
@@ -2,6 +2,7 @@ import FeatureListPage from '@/components/FeatureListPage';
 
 const features = [
   'Drawing version control and centralized file storage',
+  'Model coordination and design review',
   'RFI, submittal, and meeting minutes workflows',
   'Daily logs, change orders, and punch lists',
 ];

--- a/src/pages/Features/EquipmentMaintenance.tsx
+++ b/src/pages/Features/EquipmentMaintenance.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { Page } from '@/components/Layout';
+import { supabase } from '@/lib/supabase';
+import type { Database } from '@/lib/database.types';
+
+interface MaintenanceRecord {
+  id: string;
+  equipment_id: string;
+  description: string;
+  service_date: string;
+  service_provider: string | null;
+  notes: string | null;
+}
+
+export default function EquipmentMaintenance() {
+  const [records, setRecords] = useState<MaintenanceRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchRecords = async () => {
+      const { data, error } = await supabase.from('equipment_maintenance').select('*');
+      if (!error && Array.isArray(data)) setRecords(data as unknown as MaintenanceRecord[]);
+      setLoading(false);
+    };
+    void fetchRecords();
+  }, []);
+
+  if (loading) return <Page>Loading…</Page>;
+
+  return (
+    <Page>
+      <h1 className="text-2xl font-bold mb-4">Equipment Maintenance</h1>
+      <ul className="space-y-2">
+        {records.map(r => (
+          <li key={r.id} className="border p-2 rounded">
+            <span className="font-medium">{r.description}</span>
+            <span className="ml-2 text-sm text-gray-500">{r.service_date}</span>
+            {r.service_provider && (
+              <span className="ml-2 text-sm text-gray-500">{r.service_provider}</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </Page>
+  );
+}

--- a/src/pages/Features/EquipmentManagement.tsx
+++ b/src/pages/Features/EquipmentManagement.tsx
@@ -1,0 +1,11 @@
+import FeatureListPage from '@/components/FeatureListPage';
+
+const features = [
+  'Equipment inventory with assignments',
+  'Maintenance schedules and service logs',
+  'Usage tracking and depreciation forecasting',
+];
+
+export default function EquipmentManagement() {
+  return <FeatureListPage title="Equipment Management" features={features} />;
+}

--- a/src/pages/Features/FieldOperations.tsx
+++ b/src/pages/Features/FieldOperations.tsx
@@ -3,6 +3,7 @@ import FeatureListPage from '@/components/FeatureListPage';
 const features = [
   'Timecards and production quantity tracking',
   'Equipment assignments and usage logs',
+  'Equipment maintenance scheduling and service history',
   'Safety inspections and incident reporting',
 ];
 

--- a/supabase/migrations/20250709230000_create_design_reviews.sql
+++ b/supabase/migrations/20250709230000_create_design_reviews.sql
@@ -1,0 +1,37 @@
+-- Create design_reviews table and simple CRUD RPCs
+create table if not exists public.design_reviews (
+    id uuid primary key default gen_random_uuid(),
+    project_id uuid references public.projects(id) on delete cascade,
+    title text not null,
+    status text default 'Open',
+    notes text,
+    review_date date,
+    created_at timestamp with time zone default now(),
+    created_by uuid references public.profiles(id)
+);
+
+create or replace function public.get_design_reviews(_project_id uuid)
+returns setof design_reviews
+language sql as $$
+  select * from public.design_reviews
+  where project_id = _project_id
+  order by review_date desc nulls last, created_at desc;
+$$;
+
+create or replace function public.insert_design_review(
+    _project_id uuid,
+    _title text,
+    _status text default 'Open',
+    _notes text default null,
+    _review_date date default null,
+    _created_by uuid
+) returns uuid language plpgsql as $$
+declare
+  new_id uuid;
+begin
+  insert into public.design_reviews (project_id, title, status, notes, review_date, created_by)
+  values (_project_id, _title, _status, _notes, _review_date, _created_by)
+  returning id into new_id;
+  return new_id;
+end;
+$$;

--- a/supabase/migrations/20250709231000_create_equipment_maintenance.sql
+++ b/supabase/migrations/20250709231000_create_equipment_maintenance.sql
@@ -1,0 +1,39 @@
+-- Create equipment_maintenance table and simple CRUD RPCs
+create table if not exists public.equipment_maintenance (
+    id uuid primary key default gen_random_uuid(),
+    equipment_id uuid references public.equipment(id) on delete cascade,
+    description text not null,
+    service_date date not null,
+    service_provider text,
+    notes text,
+    created_at timestamp with time zone default now(),
+    created_by uuid references public.profiles(id)
+);
+
+create or replace function public.get_equipment_maintenance(_equipment_id uuid)
+returns setof equipment_maintenance
+language sql as $$
+  select * from public.equipment_maintenance
+  where equipment_id = _equipment_id
+  order by service_date desc, created_at desc;
+$$;
+
+create or replace function public.insert_equipment_maintenance(
+    _equipment_id uuid,
+    _description text,
+    _service_date date,
+    _service_provider text default null,
+    _notes text default null,
+    _created_by uuid
+) returns uuid language plpgsql as $$
+declare
+  new_id uuid;
+begin
+  insert into public.equipment_maintenance (
+    equipment_id, description, service_date, service_provider, notes, created_by
+  ) values (
+    _equipment_id, _description, _service_date, _service_provider, _notes, _created_by
+  ) returning id into new_id;
+  return new_id;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add design reviews and equipment maintenance feature pages
- wire new routes for these pages
- document new pages in the README
- provide SQL migrations for design review and equipment maintenance tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686edcc54b2c832c9821085abf11fe48