### PR TITLE
Fix onboarding form validations and add location autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Our long-term roadmap aims to match the capabilities of leading construction and
 - Regulatory compliance tracking
 - 3rd-party app integrations
 
+## 🧩 Custom Hooks
+
+- `useLocationSuggestions(query)` – returns an array of location names from OpenStreetMap based on the query. Useful for building autocomplete inputs so user-entered locations are standardized.
+
 ## 🐛 Troubleshooting Authentication
 If you see an error like `error running hook URI: pg-functions://postgres/public/custom-access-token_hook` during sign-in, the database function for custom access tokens may be missing.
 Run the migrations to recreate it:

--- a/src/hooks/useLocationSuggestions.ts
+++ b/src/hooks/useLocationSuggestions.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+
+export interface LocationSuggestion {
+  display_name: string;
+}
+
+/**
+ * Hook to fetch location suggestions from OpenStreetMap's Nominatim API
+ * based on a query string. Returns a list of formatted location names.
+ */
+export function useLocationSuggestions(query: string): LocationSuggestion[] {
+  const [suggestions, setSuggestions] = useState<LocationSuggestion[]>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    if (query.trim().length < 2) {
+      setSuggestions([]);
+      return () => {
+        controller.abort();
+      };
+    }
+
+    const fetchSuggestions = async (): Promise<void> => {
+      try {
+        const url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&limit=5&q=${encodeURIComponent(query)}`;
+        const res = await fetch(url, { signal: controller.signal, headers: { 'Accept-Language': 'en' } });
+        if (!res.ok) return;
+        const data = (await res.json()) as Array<{ display_name: string }>;
+        const list = Array.isArray(data) ? data.map(item => ({ display_name: item.display_name })) : [];
+        setSuggestions(list);
+      } catch (err) {
+        if (!(err instanceof DOMException && err.name === 'AbortError')) {
+          console.error('Failed to fetch location suggestions:', err);
+        }
+        setSuggestions([]);
+      }
+    };
+
+    void fetchSuggestions();
+
+    return () => {
+      controller.abort();
+    };
+  }, [query]);
+
+  return suggestions;
+}

--- a/src/pages/StandardPages/UserOnboarding.tsx
+++ b/src/pages/StandardPages/UserOnboarding.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
 import { useAuthStore } from '@/lib/store';
 import { rpcClient } from '@/lib/rpc.client';
+import { useLocationSuggestions } from '@/hooks/useLocationSuggestions';
 import type { AuthEnrichedProfileInput } from '@/hooks/useAuth';
 
 type UserRole = AuthEnrichedProfileInput['role'];
@@ -17,6 +18,7 @@ export default function UserOnboarding() {
   const isLoading = loading.auth || loading.profile;
   const roleOptions = useEnumOptions('user_role');
   const { user, profile } = useAuthStore();
+  const locationSuggestions = useLocationSuggestions(form.location ?? '');
 
   // Check if user is already logged in with a complete profile
   useEffect(() => {
@@ -151,6 +153,15 @@ export default function UserOnboarding() {
               />
             </div>
 
+            <ul className="text-xs text-gray-400 mt-2 space-y-1">
+              <li className={/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email) ? 'text-green-500' : 'text-red-500'}>
+                {/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email) ? '✔' : '✖'} Valid email
+              </li>
+              <li className={form.password.length >= 6 ? 'text-green-500' : 'text-red-500'}>
+                {form.password.length >= 6 ? '✔' : '✖'} Password at least 6 characters
+              </li>
+            </ul>
+
             <div className="mt-4 flex justify-end">
               <button
                 type="button"
@@ -233,9 +244,27 @@ export default function UserOnboarding() {
                 placeholder="e.g. New York, NY"
                 value={form.location ?? ''}
                 onChange={(e) => setForm({ ...form, location: e.target.value })}
+                list="location-suggestions"
                 className="w-full bg-background border border-background-lighter text-white px-4 py-2 rounded"
               />
+              <datalist id="location-suggestions">
+                {locationSuggestions.map((loc) => (
+                  <option key={loc.display_name} value={loc.display_name} />
+                ))}
+              </datalist>
             </div>
+
+            <ul className="text-xs text-gray-400 mt-2 space-y-1">
+              <li className={form.full_name.trim() ? 'text-green-500' : 'text-red-500'}>
+                {form.full_name.trim() ? '✔' : '✖'} Full name
+              </li>
+              <li className={form.username.trim().length >= 3 ? 'text-green-500' : 'text-red-500'}>
+                {form.username.trim().length >= 3 ? '✔' : '✖'} Username (min 3 chars)
+              </li>
+              <li className={usernameAvailable === true ? 'text-green-500' : 'text-red-500'}>
+                {usernameAvailable === true ? '✔ Username available' : usernameAvailable === false ? '✖ Username taken' : '… Checking username'}
+              </li>
+            </ul>
 
             <div className="mt-4 flex justify-between">
               <button
@@ -271,7 +300,7 @@ export default function UserOnboarding() {
                   }
                   setStep(3);
                 }}
-                disabled={Boolean(usernameAvailable !== true || isLoading)}
+                disabled={isLoading || usernameAvailable === false}
                 className="px-4 py-2 bg-primary hover:bg-primary-hover rounded disabled:opacity-50"
               >
                 Next


### PR DESCRIPTION
## Summary
- show field completion checks for each onboarding step
- enable location autocomplete using OpenStreetMap
- fix disabled logic for next button
- document `useLocationSuggestions` hook in README

## Testing
- `npm test` *(fails: eslint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f09655174832c94bb9b2820fff708