### PR TITLE
Add global error logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ Our long-term roadmap aims to match the capabilities of leading construction and
 
 - `useLocationSuggestions(query)` – returns an array of location names from OpenStreetMap based on the query. Useful for building autocomplete inputs so user-entered locations are standardized.
 
+## 🐞 Error Logging
+
+Call `initGlobalErrorLogger()` during startup to capture uncaught errors and promise rejections. Logs include the error message and stack trace for easier debugging.
+
 ## 🐛 Troubleshooting Authentication
 If you see an error like `error running hook URI: pg-functions://postgres/public/custom-access-token_hook` during sign-in, the database function for custom access tokens may be missing.
 Run the migrations to recreate it:

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,9 @@ import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
 import './index.css';
+import { initGlobalErrorLogger } from './utils/errorLogger';
+
+initGlobalErrorLogger();
 
 /**
  * Clears any stale auth/session artifacts on page load.

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -5,3 +5,24 @@ export function logError(scope: string, error: unknown): void {
     full: error,
   });
 }
+
+let isInitialized = false;
+
+/**
+ * Registers global listeners for `error` and `unhandledrejection` events.
+ * Logged errors include message and stack for easier debugging.
+ *
+ * Call once at application startup.
+ */
+export function initGlobalErrorLogger(scope = 'global'): void {
+  if (isInitialized) return;
+  isInitialized = true;
+
+  window.addEventListener('error', (event) => {
+    logError(`${scope}:error`, event.error ?? event.message);
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    logError(`${scope}:unhandledrejection`, event.reason);
+  });
+}


### PR DESCRIPTION
## Summary
- create `initGlobalErrorLogger` to capture uncaught errors and promise rejections
- call the logger during application startup
- document new error logging utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68717054d1cc832c848f04f3bb6a99ba